### PR TITLE
added hyperlinks to files in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
 # Beer rewards program
 
 ### A loyalty reward program to keep track of the amount of different beers a customer drinks at a restaurant.
+
+- [Install](/docs/install.md)
+- [Roadmap](/docs/roadmap.md)


### PR DESCRIPTION
Github now supports relative links in urls--actually rewriting them when referencing specific branches and such. The immediate change that makes sense is to add hyperlinks to the docs from the main readme.
